### PR TITLE
Update Leon Geo.ipynb

### DIFF
--- a/Leon Geo.ipynb
+++ b/Leon Geo.ipynb
@@ -328,7 +328,7 @@
     }
    ],
    "source": [
-    "df[\"mph\"] = df[\"Trip Miles\"] / (df[\"Trip Seconds\"] *3600)\n",
+    "df[\"mph\"] = df[\"Trip Miles\"] / (df[\"Trip Seconds\"] /3600)\n",
     "plt.hist(df[\"mph\"])"
    ]
   },


### PR DESCRIPTION
line 331

/ 3600 anstatt * 3600

um mph zu erhalten. Dann sollte das Histogramm auch aufschlussreicher sein.
Gute Idee sich mph anzuschauen. wäre ja bspw. relevant um aussagen über den Verbrauch der E autos zu trffen